### PR TITLE
Add GitHub Actions CI and refresh CLAUDE.md

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # Go module dependencies.
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # One PR for routine patch/minor bumps instead of many.
+      go-dependencies:
+        update-types: [minor, patch]
+
+  # Versions of the actions pinned in .github/workflows.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        update-types: [minor, patch]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,89 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel superseded runs on the same ref (e.g. force-pushes to a PR).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "These files are not gofmt-clean:"
+            echo "$unformatted"
+            exit 1
+          fi
+      - name: Vet
+        run: go vet ./...
+      - name: Build
+        run: go build ./...
+      - name: Test
+        run: go test ./... -count=1
+
+  # Per-PR race tier: full suite (NOT -short — the -short gate skips the
+  # highest-value concurrency tests: TestParallelBuilderStress,
+  # TestParallelBuilderConcurrentBuilds, TestRapidOpenClose). A single full
+  # run is ~2 min; deeper stress (repeat + GOMAXPROCS variation) runs on
+  # merge to main via race-stress.yml.
+  race:
+    name: race (full)
+    runs-on: ubuntu-latest
+    env:
+      # Remember more prior accesses so races with longer gaps still report.
+      GORACE: history_size=2
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Test (race)
+        run: go test -race -count=1 -timeout 15m ./...
+
+  lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          # golangci-lint-action manages its own analysis cache.
+          cache: false
+      - uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.12.2
+
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Vulnerability scan
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, so newly-published CodeQL queries run against the codebase
+    # even without new commits.
+    - cron: '27 4 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: analyze (go)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Install the exact toolchain from go.mod before CodeQL builds, so the
+      # extractor compiles against go1.26 rather than a runner-default Go.
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: go
+          build-mode: manual
+          queries: security-and-quality
+
+      - name: Build
+        run: go build ./...
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:go

--- a/.github/workflows/race-stress.yml
+++ b/.github/workflows/race-stress.yml
@@ -1,0 +1,41 @@
+name: Race Stress
+
+# Tier 2: deeper concurrency fuzzing that gates the MERGED state of main
+# (and on-demand), kept off the per-PR critical path. A single -race run is
+# non-deterministic and only reports races on the interleavings it happens to
+# hit, so here we re-run (-count) and vary GOMAXPROCS (-cpu) to sample many
+# more schedulings.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  stress:
+    name: race stress
+    runs-on: ubuntu-latest
+    env:
+      # Deeper access history than the per-PR job: catches races whose
+      # conflicting accesses are further apart, at the cost of more memory.
+      GORACE: history_size=4
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # Whole suite, repeated, to shake out rare races anywhere.
+      - name: Full suite (race, repeated)
+        run: go test -race -count=3 -timeout 30m ./...
+
+      # Hammer the concurrency-specific tests across multiple GOMAXPROCS
+      # settings. 20 repeats x 3 cpu profiles = 60 executions of each test.
+      - name: Concurrency stress (race, repeat + GOMAXPROCS sweep)
+        run: |
+          go test -race \
+            -run 'Parallel|Concurrent|Unsorted|RapidOpenClose' \
+            -count=20 -cpu=1,2,4 -timeout 30m .

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,24 @@
+version: "2"
+
+# Uses golangci-lint's default linter set (errcheck, govet, ineffassign,
+# staticcheck, unused). Genuine findings are fixed in code; the exclusions
+# below only silence best-effort error returns that are intentionally ignored.
+linters:
+  settings:
+    errcheck:
+      # Cleanup/close calls whose error is deliberately not actionable.
+      exclude-functions:
+        - (*os.File).Close
+        - os.Remove
+        - os.RemoveAll
+        - os.MkdirAll
+  exclusions:
+    rules:
+      # Tests routinely defer Close() on builders/indexes without checking.
+      - path: _test\.go
+        linters:
+          - errcheck
+      # cmd/bench is internal benchmarking tooling, not library code.
+      - path: cmd/bench/
+        linters:
+          - errcheck

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,262 +1,97 @@
-# Repository Work Rules
+# StreamHash
 
-## DO NOT MODIFY THIS DIRECTORY DIRECTLY
+A Go library for building and querying **Minimal Perfect Hash Function (MPHF)**
+indexes over billions of keys, using bounded RAM and streaming construction. An
+MPHF maps N keys to N consecutive integers `[0, N)` with no collisions, giving
+O(1) lookups without storing the keys themselves. The output is a single mmap'd
+file; payloads and fingerprints are optional.
 
-This is the main repository checkout. All development work MUST be done in a separate git worktree.
+Two block algorithms (see `algorithm.go`):
+- `AlgoBijection` — EF/GR encoding, compact (~2.5 bits/key), O(128) query.
+- `AlgoPTRHash` — Cuckoo with 8-bit pilots, slightly larger (~2.7 bits/key), O(1) query.
 
-## Worktree Rules
+Three build paths: `NewSortedBuilder` (sorted input), `NewUnsortedBuilder`
+(unsorted, uses per-writer temp files), and parallel builds via `WithWorkers(n)`.
 
-1. **Never commit to master or this directory** - This checkout should remain clean.
+## Build & Test
 
-2. **Each task gets its own worktree** - Before starting work, create or use a dedicated worktree:
-   ```bash
-   git worktree add ../streamsplit-<task-name> -b <branch-name>
-   ```
+- `go test ./...` — full suite.
+- `go test -short ./...` — fast subset. **Note:** `-short` skips large-scale and
+  the heaviest concurrency tests (`TestParallelBuilderStress`,
+  `TestParallelBuilderConcurrentBuilds`, `TestRapidOpenClose`, …).
+- `go test -race ./...` — run this for any change touching the builders. Do **not**
+  pair it with `-short`: that would skip exactly the concurrency tests worth racing.
+- `go vet ./...`, `gofmt -l .`, and `golangci-lint run` must all be clean — CI enforces them.
 
-3. **Existing worktrees** - Check for existing worktrees before creating new ones:
-   ```bash
-   git worktree list
-   ```
+## Platform
 
-4. **Use absolute paths** - Always use the full path to your worktree (e.g., `/Users/tamir/streamsplit-two-zone`) for all file operations and git commands.
+Unix-only: `platform_{linux,darwin,other}.go` all import `golang.org/x/sys/unix`
+(for `fallocate`/`fcntl`), so the library does **not** build on Windows. CI runs
+on ubuntu + macos only.
 
-5. **Current active worktree** - If continuing existing work, check which worktree is relevant to the task and work there.
+## Concurrency
 
-6. **Always rebase onto master before starting work** - Before making any changes or applying any edits to a worktree branch, run:
-   ```bash
-   cd <worktree-path> && git fetch origin && git rebase master
-   ```
-   If the branch has uncommitted changes, stash them first. If the branch has commits that conflict with master, resolve the rebase BEFORE doing any new work. Never start applying changes to a branch that is behind master — this causes merge conflicts later that waste time and risk losing work.
+The builders are heavily concurrent and are the main correctness risk:
+- **Sorted parallel** (`builder_parallel.go`): an `errgroup` worker pool builds
+  blocks; a single writer goroutine emits them in block order via channels.
+- **Unsorted** (`builder_unsorted*.go`): concurrent writers each own a temp file
+  (lock-free `pwrite`); the finish phase uses a reader goroutine pool with
+  per-slot fences.
 
-7. **Clean up after merging** - After a branch is merged to master, immediately delete the worktree and branch:
-   ```bash
-   git worktree remove /Users/tamir/streamsplit-<task-name>
-   git branch -d <branch-name>
-   ```
-   Do not leave stale worktrees or merged branches lying around.
+Treat the race detector as a first-class gate, and keep per-test timeouts on the
+channel/`errgroup` code so a deadlock fails the run instead of hanging it. If a
+test genuinely times out only under `-race`, fix it or skip it under race with a
+documented reason — never leave it flaky.
 
-## Example Workflow
+## CI
 
-```bash
-# List existing worktrees
-git worktree list
-
-# Create a new worktree for a feature
-git worktree add ../streamsplit-my-feature -b my-feature
-
-# All work happens in the worktree
-cd ../streamsplit-my-feature
-# ... make changes, run tests, commit ...
-
-# After merging to master, clean up
-git worktree remove ../streamsplit-my-feature
-git branch -d my-feature
-```
-
-## Why This Matters
-
-- Keeps the main checkout clean for reference
-- Allows parallel work on multiple features
-- Prevents accidental commits to wrong branches
-- Each agent/task is isolated from others
-
-## Git Safety
-
-Before running `git checkout <file>`, `git restore <file>`, or `git stash`:
-1. Check if the file has uncommitted changes: `git status <file>`
-2. If it does, backup first: `cp <file> <file>.backup`
-
-Never assume uncommitted changes can be "restored" from git - they can't.
+- `ci.yml` — build, gofmt, vet, tests (ubuntu+macos), full `-race`, golangci-lint,
+  govulncheck. Runs on push to `main` and all PRs.
+- `race-stress.yml` — deeper concurrency fuzzing on merge to `main` (and manual
+  dispatch): full suite `-race -count=3`, plus the concurrency tests at
+  `-count=20 -cpu=1,2,4` to sample many goroutine interleavings.
+- `codeql.yml` — CodeQL security-and-quality, push/PR + weekly.
+- `dependabot.yml` — weekly grouped gomod + actions updates.
 
 ## Performance Regression Testing
 
-Use `cmd/bench` to check for performance regressions. Run benchmarks before and after changes to compare.
-
-### MPHF Mode (primary test)
-
-Test the core MPHF build performance with 10M keys:
+Use `cmd/bench` to check for regressions; run before and after a change and
+compare "Build throughput" (M/sec).
 
 ```bash
+# MPHF mode — Cuckoo solver only, no payload/fingerprint overhead.
 go run ./cmd/bench -keys 10000000 -payload 0 -algo ptrhash -workers 1
-```
 
-This tests the Cuckoo solver without payload/fingerprint overhead. Look at "Build throughput" (M/sec).
-
-### Default Mode (with payload + fingerprint)
-
-Also test the full code path including payload and fingerprint:
-
-```bash
+# Default mode — full code path (4-byte payload, 1-byte fingerprint).
 go run ./cmd/bench -keys 10000000 -algo ptrhash -workers 1
 ```
 
-This uses the default payload (4 bytes) and fingerprint (1 byte).
+To compare against a baseline, run on `HEAD`, then `git stash && git checkout
+<baseline>`, run again, and restore. **Run benchmarks serially** — never two at
+once; they contend for CPU/memory bandwidth and produce noise. Do 5+ iterations
+each; a difference under ~5% is within noise.
 
-### Comparing Against Baseline
+## Correctness Priorities
 
-To compare performance against a baseline commit:
+Correctness across the **full parameter space** is the top priority — not just the
+default configuration. Code that only works for the common case is buggy.
 
-```bash
-# Run current version
-go run ./cmd/bench -keys 10000000 -payload 0 -algo ptrhash -workers 1
+- Every valid combination of payload size, fingerprint size, and algorithm must
+  produce correct results.
+- When a specialized/optimized path exists alongside the generic one, verify they
+  produce **byte-identical** output.
+- Watch for hardcoded assumptions about configurable sizes (e.g. `<< 8` assuming a
+  1-byte field). These are silent for the default config and only break others.
+- For any unbounded counter, analyze wrap-around and the consequence of a stale
+  match; prefer a cheap guard over relying on probability.
+- Before changing a function's behavior (adding a panic, removing a fallback), grep
+  all callers including tests.
 
-# Stash changes, checkout baseline, run again
-git stash
-git checkout <baseline-commit>
-go run ./cmd/bench -keys 10000000 -payload 0 -algo ptrhash -workers 1
+## What NOT to Change
 
-# Restore
-git checkout -
-git stash pop
-```
-
-Run 5+ iterations of each to account for variance. A difference of <5% is typically within noise.
-
-**Always run benchmarks serially.** Never run multiple benchmark processes in parallel — they contend for the same CPU, memory bandwidth, and cache, producing unreliable results.
-
-## Test Failures
-
-- **Never dismiss test failures as "pre-existing" or "unrelated".** Every failure must be investigated and either fixed or explicitly tracked. A test that times out under `-race` is a real problem — fix it (e.g., skip under race detector with a clear reason) rather than ignoring it.
-- If a test fails in a package you didn't change, investigate the root cause. It may reveal a real bug, a missing build tag, or an environment issue.
-
-## Plan Execution Rules
-
-- **Every section of an approved plan MUST be executed**, including verification, benchmarks, and profiling. Do not declare work complete until all sections are done.
-- **Create a separate task for EACH verification step** (go vet, tests, benchmarks, profiling). A single "run tests" task is not sufficient — each verification type gets its own task.
-- **Benchmarks and profiling are mandatory**, not optional. They catch performance regressions that tests alone cannot detect.
-- **Before changing function behavior** (e.g., adding a panic, removing a fallback), grep ALL callers including test files. Do not assume a code path is "dead" without verifying no tests exercise it.
-
-## Code Review & Quality Improvement Checklist
-
-Apply this checklist when reviewing code or improving code quality.
-
-**Review methodology:**
-
-- **Systematic, grep-verified audit**: Every exported symbol must be verified with `grep pkg.SymbolName` outside the package. Every struct field must have both write and read sites identified. Every magic number must be traced to a named constant or commented.
-- **Multi-pass sweep**: First pass scans for structural issues (dead code, exports, DRY). Second pass checks correctness (overflow, off-by-one, parameter assumptions). Third pass checks comments/naming/tests.
-- **Checklist-driven, not scan-and-spot**: Each checklist item applied to every relevant code element, not just the ones that catch the eye.
-- **No finding is too small**: Report inconsistencies even if technically correct (e.g., `<< 1` vs `<< 8` for the same composite key pattern).
-
-**Correctness is the top priority.** Every review must actively verify that code produces correct results for all valid inputs — not just the common case. Look for untested parameter combinations, optimized paths that diverge from the generic path, and hardcoded assumptions about configurable values. A bug that only manifests in uncommon configurations is still a bug.
-
-### 1. Comments & Documentation Accuracy
-
-- [ ] **Redundant naming**: Does the comment repeat the package/type/function name unnecessarily?
-- [ ] **Stale references**: Do comments reference function/method/type names that have since been renamed or deleted?
-- [ ] **Orphaned section headers**: Are there section-separator comments for code that was removed, leaving an empty section?
-- [ ] **Wrong types in comments**: Do comments describe the correct types?
-- [ ] **Misleading descriptions**: Does the comment accurately describe what this function does, not what a different function does?
-- [ ] **Stale casing after visibility changes**: After exporting/unexporting, do comments still reference the old casing?
-- [ ] **Mismatched error names in tests**: Do test assertion messages name the correct error?
-- [ ] **Non-obvious guards explained**: Is there a comment explaining why a correctness guard exists when the reason isn't self-evident?
-- [ ] **Clever techniques documented**: Are non-standard algorithmic tricks explained?
-- [ ] **Rationale for constraints**: Are arbitrary-looking constraints explained?
-- [ ] **Shared-but-independent state**: When two arrays share a generation counter but track different things, is that relationship documented?
-- [ ] **Algorithm/constant attribution**: Are well-known constants cited with their source?
-
-### 2. Magic Numbers
-
-- [ ] **Idiomatic alternatives**: Can bit manipulation be replaced with standard library constants?
-- [ ] **Statistical context**: Do multipliers of statistical parameters have comments explaining what percentile they target?
-- [ ] **Minimum floors**: Are minimum values explained?
-- [ ] **Fractions of totals**: Are fractional allocations explained?
-- [ ] **Safety margins**: Are additive safety margins justified?
-- [ ] **Repeated values**: Is the same magic number used in multiple places? Extract to a named constant to keep them in sync.
-
-### 3. Dead Code & Leftovers
-
-- [ ] **Test-only symbols in production files**: Are there any functions, types, constants, or variables (exported or unexported) that live in non-test files but are only referenced by test code? Move into a `_test.go` file or delete if the test should use the real production function instead.
-- [ ] **Orphaned artifacts**: Are there functions, types, or test helpers that are artifacts of a previous design?
-- [ ] **Tests testing dead code**: Are there tests that only exercise dead/trivial helpers and provide no real coverage?
-- [ ] **Assertion-free tests**: Are there tests that call functions and log results but never assert? They exercise code paths but can't catch regressions.
-- [ ] **Stray blank lines**: Extra blank lines between or inside functions that don't serve a grouping purpose.
-
-### 4. DRY / Duplication
-
-- [ ] **Identical implementations on different types**: Do two types have methods with the same body? Extract to a shared function.
-- [ ] **Same calculation in multiple places**: Is the same formula copy-pasted? Extract to a single function.
-- [ ] **Same constant value in multiple call sites**: Should it be a named constant?
-- [ ] **Inconsistent patterns in tests**: Is the same thing done differently in different test files?
-
-### 5. Naming
-
-- [ ] **Variables serving double duty**: Does a variable name describe only one of its uses?
-- [ ] **Test names matching current code**: Do test function names still match the types/functions they test after refactoring?
-- [ ] **Variable shadowing**: Does a local variable shadow a function, parameter, or outer variable with the same name?
-- [ ] **Ambiguous numeric suffixes**: Does a function name end with a number that could be misread? E.g., `WriteEntry5` — is it entry #5 or a 5-byte entry? Prefer a parameter (`WriteEntry(…, 5, …)`) or explicit units (`WriteEntry5B`) over bare numeric suffixes.
-
-### 6. Abstraction & Structure
-
-- [ ] **Unnecessary wrapper types**: Is there a type that wraps another 1:1, adding only a few fields and forwarding methods? Merge them.
-- [ ] **Trivial delegation pairs**: Are there public methods that just call a private method with no additional logic? Inline the private method.
-- [ ] **File length**: Are files over ~500-600 lines? Can they be split along natural seams?
-- [ ] **Split criteria**: Orchestration/entry points in one file. Self-contained algorithmic routines in another. Independent data structures in a third.
-
-### 7. Visibility / Export Surface
-
-- [ ] **Over-exported internal symbols**: Are symbols exported that are only used within the package? Unexport them.
-- [ ] **Audit each export**: For every exported symbol, verify at least one caller exists outside the package. If not, unexport.
-- [ ] **Keep exported**: Symbols that implement interfaces consumed by other packages, or are used in external test files.
-
-### 8. Idiomatic Go
-
-- [ ] **`clear()` over manual zero loops** (Go 1.21+)
-- [ ] **`math.MaxInt`** over bit manipulation
-- [ ] **`t.Logf`** over `fmt.Printf` in tests
-- [ ] **Unexport** what isn't part of the API contract
-
-### 9. Correctness
-
-- [ ] **Full parameter space coverage**: Does every valid combination of configuration parameters have a test? Code that only works for the default/common configuration is buggy — if a parameter is configurable, all valid values must produce correct results.
-- [ ] **Optimized path parity**: When specialized/optimized code paths exist alongside a generic path, do tests verify they produce identical results? A parity check (specialized output == generic output, byte-for-byte) catches bugs that value-level checks alone might miss.
-- [ ] **Hardcoded parameter assumptions**: Does the code hardcode a value that should be derived from a configuration parameter? E.g., `<< 8` assuming a 1-byte field when the field size is configurable. These bugs are silent for the default configuration and only surface for other valid inputs.
-- [ ] **Integer overflow / wrap-around**: For any counter that increments without bound, analyze: what type is it? When does it wrap? What happens at wrap?
-- [ ] **Probability analysis**: How many increments per unit of work? How many units before wrap? What's the probability of a stale match?
-- [ ] **Consequence analysis**: Is a false match benign or catastrophic?
-- [ ] **Add guards for negligible probabilities**: If a guard is cheap, add it to make the code provably correct rather than probabilistically correct.
-
-### 10. Coupling, Cohesion & Responsibility
-
-**Cohesion**
-
-- [ ] **Artificial type separation**: Is there a type that only exists as a thin wrapper around another it's always 1:1 with? Merge them.
-- [ ] **Scattered knowledge**: Is the same domain concept encoded independently in multiple places? Extract to a single source of truth.
-- [ ] **Function placement**: Does the function live near the data it operates on, or is it stranded far from its receiver type and the state it reads?
-- [ ] **File cohesion**: Can you describe what a file is "about" in one phrase? If not, it may be doing too much.
-
-**Coupling**
-
-- [ ] **Minimal export surface**: Every exported symbol is a coupling point. Does each export have a consumer outside the package?
-- [ ] **Shared mutable state**: When two subsystems share state, is the coupling documented and are the invariants clear? Could they be decoupled?
-- [ ] **Unnecessary indirection**: Does calling function A always call function B with no additional logic? Inline it.
-- [ ] **Always-paired calls**: Are two functions always called together in sequence (A then B, never independently)? Combine them into a single function.
-- [ ] **Interface/contract width**: Are types exposing methods/fields that callers don't need?
-
-**Single Responsibility**
-
-- [ ] **Functions doing two things**: Does a function both compute something and mutate unrelated state? Can those be separated?
-- [ ] **Variables serving multiple roles**: Does a variable change meaning mid-function?
-- [ ] **Types with orthogonal concerns**: Does a type mix algorithm state with buffer management or configuration? If the concerns change independently, consider separation — but only if the separation is real, not artificial.
-
-**Dependency Direction**
-
-- [ ] **One-way dependencies**: Do files/types form a DAG, or are there circular references?
-- [ ] **Stable dependencies**: Do volatile components depend on stable ones, or the reverse?
-
-### 11. Efficiency & Standard Library Usage
-
-- [ ] **Reimplemented standard library or well-established third-party library**: Is there hand-written code that duplicates something available in the standard library or a widely-used, well-maintained third-party package?
-- [ ] **Suboptimal data structures**: Is a slice used where a map would give O(1) lookup? Is a map used where a slice with index access would avoid hashing overhead? Does the access pattern match the data structure?
-- [ ] **Redundant allocations**: Are slices or maps allocated inside loops when they could be allocated once and reused or reset with `clear()`? Are temporary buffers created per-call when a pre-allocated field on the struct would suffice?
-- [ ] **Unnecessary conversions**: Are values converted back and forth between types when the computation could stay in one type?
-- [ ] **Quadratic patterns hiding in loops**: Is there an O(n) algorithm available where the code uses O(n²)?
-- [ ] **Oversized allocations**: Are buffers pre-allocated for worst-case when a right-sized allocation based on actual input would be significantly smaller?
-- [ ] **String building**: Is string concatenation in a loop used where `strings.Builder` or `fmt.Sprintf` would be more efficient?
-- [ ] **Available in newer Go versions**: Has a recent Go release added a builtin or standard library function that replaces hand-written code?
-
-### 12. What NOT to Change
-
-- [ ] **Intentional hot-path duplication**: Unrolled/specialized functions that eliminate branches. The duplication is the optimization.
-- [ ] **Unsafe operations on hot paths**: If properly bounds-checked, performance-critical, and internal-only, leave them.
-- [ ] **Missing validation on query hot paths**: If correctness is ensured at a higher level, don't add per-query validation that would hurt throughput.
-- [ ] **Performance-critical code patterns**: Don't refactor for readability if it would regress performance. Document the intent instead.
+- **Intentional hot-path duplication**: unrolled/specialized functions that
+  eliminate branches — the duplication *is* the optimization.
+- **Unsafe / bounds-check-free operations on query hot paths**, where correctness is
+  guaranteed at a higher level. Don't add per-query validation that hurts throughput.
+- Don't refactor performance-critical code for readability if it would regress
+  performance; document the intent instead.

--- a/builder_parallel.go
+++ b/builder_parallel.go
@@ -317,7 +317,8 @@ func (b *builder) runWriter() {
 			}
 
 			// Return metadata buffer to pool for reuse
-			b.metadataPool.Put(r.metadata[:cap(r.metadata)])
+			//lint:ignore SA6002 slice value boxing is acceptable; pointer-to-slice adds complexity
+			b.metadataPool.Put(r.metadata[:cap(r.metadata)]) //nolint:staticcheck
 
 			nextBlockID++
 		}

--- a/builder_unsorted.go
+++ b/builder_unsorted.go
@@ -697,7 +697,7 @@ func (ub *UnsortedBuilder) AddKeys(numWriters int, fn func(writerID int, addKey 
 	}
 
 	if err := ub.initBuffer(numWriters); err != nil {
-		ub.b.cleanup()
+		_ = ub.b.cleanup() // best-effort cleanup; surface the original error
 		return err
 	}
 
@@ -706,7 +706,7 @@ func (ub *UnsortedBuilder) AddKeys(numWriters int, fn func(writerID int, addKey 
 	for i := range numWriters {
 		ws, err := ub.unsortedBuf.newWriterState()
 		if err != nil {
-			ub.Close()
+			_ = ub.Close() // best-effort cleanup; surface the original error
 			return fmt.Errorf("new writer: %w", err)
 		}
 		w := &unsortedWriter{b: ub.b, ws: ws}
@@ -733,7 +733,7 @@ func (ub *UnsortedBuilder) AddKeys(numWriters int, fn func(writerID int, addKey 
 	wg.Wait()
 
 	if err := errors.Join(errs...); err != nil {
-		ub.Close()
+		_ = ub.Close() // best-effort cleanup; surface the original error
 		return err
 	}
 

--- a/builder_unsorted_finish.go
+++ b/builder_unsorted_finish.go
@@ -320,7 +320,7 @@ func (ub *UnsortedBuilder) finishUnsortedFastPath() error {
 			base := p * ws.regionCap
 			for i := range n {
 				e := ws.flatBufs[a][base+i]
-				entries = append(entries, routedEntry{k0: e.k0, k1: e.k1, payload: e.payload})
+				entries = append(entries, routedEntry(e))
 				prefix := bits.ReverseBytes64(e.k0)
 				entryBlockIDs = append(entryBlockIDs, intbits.FastRange32(prefix, u.numBlocks))
 			}
@@ -331,7 +331,6 @@ func (ub *UnsortedBuilder) finishUnsortedFastPath() error {
 	for _, ws := range allWS {
 		ws.free()
 	}
-	allWS = nil
 
 	// Check context before doing any work
 	select {

--- a/header.go
+++ b/header.go
@@ -111,11 +111,6 @@ func (h *header) payloadSizeInt() int {
 	return int(h.PayloadSize)
 }
 
-// hasPayload returns true if the index stores payloads.
-func (h *header) hasPayload() bool {
-	return h.PayloadSize > 0
-}
-
 // hasFingerprint returns true if the index stores fingerprints.
 func (h *header) hasFingerprint() bool {
 	return h.FingerprintSize > 0

--- a/index.go
+++ b/index.go
@@ -333,7 +333,7 @@ func OpenPayload(path string) (*PayloadIndex, error) {
 	}
 	pi, err := idx.WithPayload()
 	if err != nil {
-		idx.Close()
+		_ = idx.Close() // best-effort cleanup; surface the original error
 		return nil, err
 	}
 	return pi, nil
@@ -348,7 +348,7 @@ func OpenPayloadFile(f *os.File) (*PayloadIndex, error) {
 	}
 	pi, err := idx.WithPayload()
 	if err != nil {
-		idx.Close()
+		_ = idx.Close() // best-effort cleanup; surface the original error
 		return nil, err
 	}
 	return pi, nil
@@ -363,7 +363,7 @@ func OpenPayloadBytes(data []byte) (*PayloadIndex, error) {
 	}
 	pi, err := idx.WithPayload()
 	if err != nil {
-		idx.Close()
+		_ = idx.Close() // best-effort cleanup; surface the original error
 		return nil, err
 	}
 	return pi, nil

--- a/internal/bits/bits_test.go
+++ b/internal/bits/bits_test.go
@@ -84,7 +84,7 @@ func TestFastRange32EdgeCases(t *testing.T) {
 
 	// n=MaxUint32 -> result < MaxUint32
 	got := FastRange32(math.MaxUint64, math.MaxUint32)
-	if got >= math.MaxUint32 {
+	if got == math.MaxUint32 {
 		t.Errorf("FastRange32(MaxUint64, MaxUint32) = %d, want < MaxUint32", got)
 	}
 	if got != math.MaxUint32-1 {


### PR DESCRIPTION
## Summary

Two changes:
1. Adds GitHub Actions CI to the repository (there was none) and makes the
   codebase clean under the linters the gate enforces.
2. Trims and retargets `CLAUDE.md` (262 → 97 lines).

## 1. CI

### Workflows
- **`ci.yml`** — on push to `main` and all PRs: build, `gofmt`, `go vet`,
  and tests on **ubuntu + macos** (Windows is excluded: `platform_other.go`
  imports `golang.org/x/sys/unix`, so it can't build there). Plus a full
  **`-race`** job, **golangci-lint**, and **govulncheck**.
- **`race-stress.yml`** — tier 2, on merge to `main` and `workflow_dispatch`:
  full suite `-race -count=3`, then the concurrency tests at
  `-count=20 -cpu=1,2,4` (60 executions each) to sample many goroutine
  interleavings. Kept off the per-PR critical path.
- **`codeql.yml`** — CodeQL `security-and-quality` for Go, push/PR + weekly.
- **`dependabot.yml`** — weekly grouped gomod + actions updates.
- **`.golangci.yml`** — default linter set; `errcheck` exclusions limited to
  best-effort cleanup/close calls and to tests / `cmd/bench` tooling.

### Why full `-race`, not `-short`
`-short` skips exactly the highest-value concurrency tests
(`TestParallelBuilderStress`, `TestParallelBuilderConcurrentBuilds`,
`TestRapidOpenClose`). Measured cost of going full is only ~+20s
(~80s → ~100s), so the per-PR race job runs the whole suite; the deeper
`-count`/`-cpu` sweep lives in the merge-time tier.

### Lint fixes (so the gate starts green)
All behavior-neutral; verified perf-safe (identical allocs/B/op, statistically
equal time on the unsorted build benchmarks):
- Remove unused `header.hasPayload`.
- Drop ineffectual `allWS = nil` in `finishUnsortedFastPath`.
- Use `routedEntry(e)` conversion instead of a struct literal (S1016).
- Mark intentional best-effort `Close()`/`cleanup()` returns with `_ =`.
- Suppress SA6002 on `metadataPool.Put` for parity with the existing
  `entryPool.Put` suppression.
- Compare `==` instead of `>=` against `MaxUint32` in a bits test (SA4003).

### Verified locally
`gofmt` clean, `go vet` clean, full `go test ./...` passes, full `-race` on
touched paths clean, **golangci-lint: 0 issues**.

## 2. CLAUDE.md refresh

Rewrites `CLAUDE.md` from 262 → 97 lines. Removes directives that mostly
compensated for older-model habits (worktree ceremony, git-safety nags,
plan-execution micromanagement, a ~250-line generic review checklist) and
replaces them with project knowledge that's hard to infer from the code:
orientation (what StreamHash is, the two algorithms, three build paths),
Build & Test, Platform (Unix-only), Concurrency, and CI sections. Keeps the
`cmd/bench` perf-regression workflow and the "what NOT to change" hot-path
guidance, condensed; distills correctness priorities into a short list.

## Deferred (follow-up)
A merge-time **performance-regression** job (same-runner A/B vs merge-base +
`benchstat`, hard-gating the deterministic metrics like bits/key and index
size) is intentionally left for a later commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
